### PR TITLE
libretro: Add GIT_VERSION

### DIFF
--- a/libretro/Makefile
+++ b/libretro/Makefile
@@ -1,6 +1,11 @@
 STATIC_LINKING := 0
 AR             := ar
 
+GIT_VERSION ?= " $(shell git rev-parse --short HEAD || echo unknown)"
+ifneq ($(GIT_VERSION)," unknown")
+   CFLAGS += -DGIT_VERSION=\"$(GIT_VERSION)\"
+endif
+
 ifeq ($(platform),)
 platform = unix
 ifeq ($(shell uname -a),)

--- a/libretro/jni/Android.mk
+++ b/libretro/jni/Android.mk
@@ -1,7 +1,11 @@
 LOCAL_PATH := $(call my-dir)
 
-include $(CLEAR_VARS)
+GIT_VERSION ?= " $(shell git rev-parse --short HEAD || echo unknown)"
+ifneq ($(GIT_VERSION)," unknown")
+   LOCAL_CXXFLAGS += -DGIT_VERSION=\"$(GIT_VERSION)\"
+endif
 
+include $(CLEAR_VARS)
 
 HAVE_NETWORK = 1
 LOCAL_MODULE    := libretro

--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -14,6 +14,8 @@
 #define snprintf _snprintf
 #endif
 
+#define SAMEBOY_CORE_VERSION "0.9"
+
 #include <Core/gb.h>
 #include "libretro.h"
 
@@ -168,11 +170,14 @@ void retro_get_system_info(struct retro_system_info *info)
 {
    memset(info, 0, sizeof(*info));
    info->library_name     = "SameBoy";
-   info->library_version  = "0.9";
+#ifdef GIT_VERSION
+   info->library_version  = SAMEBOY_CORE_VERSION GIT_VERSION;
+#else
+   info->library_version  = SAMEBOY_CORE_VERSION;
+#endif
    info->need_fullpath    = true;
    info->valid_extensions = "gb|gbc";
 }
-
 
 void retro_get_system_av_info(struct retro_system_av_info *info)
 {


### PR DESCRIPTION
Adds `GIT_VERSION` so the RetroArch menu will show the build's commit.