### PR TITLE
Allow build on Haiku target

### DIFF
--- a/Core/gb.c
+++ b/Core/gb.c
@@ -271,15 +271,17 @@ exit:
     return;
 }
 
-void GB_run(GB_gameboy_t *gb)
+uint8_t GB_run(GB_gameboy_t *gb)
 {
     GB_debugger_run(gb);
+    gb->cycles_since_run = 0;
     GB_cpu_run(gb);
     if (gb->vblank_just_occured) {
         GB_update_joyp(gb);
         GB_rtc_run(gb);
         GB_debugger_handle_async_commands(gb);
     }
+    return gb->cycles_since_run;
 }
 
 uint64_t GB_run_frame(GB_gameboy_t *gb)

--- a/Core/gb.h
+++ b/Core/gb.h
@@ -483,6 +483,7 @@ struct GB_gameboy_internal_s {
         uint32_t ram_size; // Different between CGB and DMG
         uint8_t boot_rom[0x900];
         bool vblank_just_occured; // For slow operations involving syscalls; these should only run once per vblank
+        uint8_t cycles_since_run; // How many cycles have passed since the last call to GB_run()
    );
 };
     
@@ -506,7 +507,9 @@ bool GB_is_cgb(GB_gameboy_t *gb);
 void GB_free(GB_gameboy_t *gb);
 void GB_reset(GB_gameboy_t *gb);
 void GB_switch_model_and_reset(GB_gameboy_t *gb, bool is_cgb);
-void GB_run(GB_gameboy_t *gb);
+
+/* Returns the time passed, in 4MHz ticks. */
+uint8_t GB_run(GB_gameboy_t *gb);
 /* Returns the time passed since the last frame, in nanoseconds */
 uint64_t GB_run_frame(GB_gameboy_t *gb);
 

--- a/Core/timing.c
+++ b/Core/timing.c
@@ -153,6 +153,7 @@ void GB_advance_cycles(GB_gameboy_t *gb, uint8_t cycles)
     gb->cycles_since_ir_change += cycles;
     gb->cycles_since_input_ir_change += cycles;
     gb->cycles_since_last_sync += cycles;
+    gb->cycles_since_run += cycles;
     GB_dma_run(gb);
     GB_hdma_run(gb);
     GB_apu_run(gb);

--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,11 @@ CFLAGS += -IWindows
 LDFLAGS += -lmsvcrt -lSDL2main -Wl,/MANIFESTFILE:NUL
 SDL_LDFLAGS := -lSDL2 -lopengl32
 else
+ifneq ($(findstring Haiku,$(shell uname -s)),)
+LDFLAGS += -lbe -lm
+else
 LDFLAGS += -lc -lm
+endif
 endif
 
 ifeq ($(PLATFORM),Darwin)

--- a/libretro/Makefile
+++ b/libretro/Makefile
@@ -147,14 +147,14 @@ CFLAGS   += -Wall -D__LIBRETRO__ $(fpic) $(INCFLAGS) -std=gnu11 -D_GNU_SOURCE -D
 
 all: $(TARGET)
 
-$(CORE_DIR)/libretro/%_boot.c: $(CORE_DIR)/build/bin/BootROMs/%_boot.bin
+$(CORE_DIR)/libretro/%_boot.c: $(CORE_DIR)/BootROMs/prebuilt/%_boot.bin
 	echo "/* AUTO-GENERATED */" > $@
 	echo "const unsigned char $(notdir $(@:%.c=%))[] = {" >> $@
 	hexdump -v -e '/1 "0x%02x, "' $< >> $@
 	echo "};" >> $@
 	echo "const unsigned $(notdir $(@:%.c=%))_length = sizeof($(notdir $(@:%.c=%)));" >> $@
 
-$(CORE_DIR)/build/bin/BootROMs/%_boot.bin:
+$(CORE_DIR)/BootROMs/prebuilt/%_boot.bin:
 	$(MAKE) -C $(CORE_DIR) $(patsubst $(CORE_DIR)/%,%,$@)
 
 $(TARGET): $(OBJECTS)

--- a/libretro/Makefile
+++ b/libretro/Makefile
@@ -65,7 +65,7 @@ EXT := a
 endif
 
 ifeq ($(platform), unix)
-    EXT ?= so
+   EXT ?= so
    TARGET := $(TARGET_NAME)_libretro.$(EXT)
    fpic := -fPIC
    SHARED := -shared -Wl,--version-script=$(CORE_DIR)/libretro/link.T -Wl,--no-undefined
@@ -150,7 +150,13 @@ all: $(TARGET)
 $(CORE_DIR)/libretro/%_boot.c: $(CORE_DIR)/BootROMs/prebuilt/%_boot.bin
 	echo "/* AUTO-GENERATED */" > $@
 	echo "const unsigned char $(notdir $(@:%.c=%))[] = {" >> $@
+ifneq ($(findstring Haiku,$(shell uname -s)),)
+	# turns out od is posix, hexdump is not hence is less portable
+	# this is still rather ugly and could be done better I guess
+	od -A none -t x1 -v $< | sed -e 's/^\ /0x/' -e 's/\ /,\ 0x/g' -e 's/$$/,/g' | tr '\n' ' ' >> $@
+else
 	hexdump -v -e '/1 "0x%02x, "' $< >> $@
+endif
 	echo "};" >> $@
 	echo "const unsigned $(notdir $(@:%.c=%))_length = sizeof($(notdir $(@:%.c=%)));" >> $@
 
@@ -176,4 +182,3 @@ clean:
 	rm -f $(OBJECTS) $(TARGET)
 
 .PHONY: clean
-

--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -36,11 +36,12 @@ char symbols_path[512];
 enum model {
     MODEL_DMG,
     MODEL_CGB,
-    MODEL_AGB
+    MODEL_AGB,
+    MODEL_AUTO
 };
 
-static enum model model = MODEL_CGB;
-
+static enum model model = MODEL_AUTO;
+static enum model auto_model = MODEL_CGB;
 static uint32_t *frame_buf;
 static struct retro_log_callback logging;
 static retro_log_printf_t log_cb;
@@ -230,20 +231,24 @@ void retro_reset(void)
 
 static void init_for_current_model(void)
 {
+    enum model effective_model = model;
+    if (effective_model == MODEL_AUTO) {
+        effective_model = auto_model;
+    }
     if (GB_is_inited(&gb)) {
-        GB_switch_model_and_reset(&gb, model != MODEL_DMG);
+        GB_switch_model_and_reset(&gb, effective_model != MODEL_DMG);
     }
     else {
-        if (model == MODEL_DMG) {
+        if (effective_model == MODEL_DMG) {
             GB_init(&gb);
         }
         else {
             GB_init_cgb(&gb);
         }
     }
-    const char *model_name = (const char *[]){"dmg", "cgb", "agb"}[model];
-    const unsigned char *boot_code = (const unsigned char *[]){dmg_boot, cgb_boot, agb_boot}[model];
-    unsigned boot_length = (unsigned []){dmg_boot_length, cgb_boot_length, agb_boot_length}[model];
+    const char *model_name = (const char *[]){"dmg", "cgb", "agb"}[effective_model];
+    const unsigned char *boot_code = (const unsigned char *[]){dmg_boot, cgb_boot, agb_boot}[effective_model];
+    unsigned boot_length = (unsigned []){dmg_boot_length, cgb_boot_length, agb_boot_length}[effective_model];
     
     char buf[256];
     snprintf(buf, sizeof(buf), "%s%c%s_boot.bin", retro_system_directory, slash, model_name);
@@ -341,9 +346,14 @@ static void check_variables(void)
             new_model = MODEL_CGB;
         else if (strcmp(var.value, "Game Boy Advance") == 0)
             new_model = MODEL_AGB;
+        else if (strcmp(var.value, "Auto") == 0)
+            new_model = MODEL_AUTO;
         if (GB_is_inited(&gb) && new_model != model) {
             model = new_model;
             init_for_current_model();
+        }
+        else {
+            model = new_model;
         }
     }
 }
@@ -390,6 +400,8 @@ bool retro_load_game(const struct retro_game_info *info)
         return false;
     }
     
+    auto_model = (info->path[strlen(info->path) - 1] & ~0x20) == 'c' ? MODEL_CGB : MODEL_DMG;
+    
     bool yes = true;
     environ_cb(RETRO_ENVIRONMENT_SET_SUPPORT_ACHIEVEMENTS, &yes);
     
@@ -401,7 +413,7 @@ bool retro_load_game(const struct retro_game_info *info)
     static const struct retro_variable vars[] = {
         { "sameboy_color_correction_mode", "Color Correction; off|correct curves|emulate hardware|preserve brightness" },
         { "sameboy_high_pass_filter_mode", "High Pass Filter; off|accurate|remove dc offset" },
-        { "sameboy_model", "Emulated Model; Game Boy Color|Game Boy Advance|Game Boy" },
+        { "sameboy_model", "Emulated Model; Auto|Game Boy|Game Boy Color|Game Boy Advance" },
         { NULL }
     };
     

--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -470,7 +470,9 @@ void *retro_get_memory_data(unsigned type)
             data = &gb.rtc_real;
          else
             data = NULL;
-            break;
+         break;
+      default:
+         data = NULL;
     }
     
     return data;
@@ -499,9 +501,9 @@ size_t retro_get_memory_size(unsigned type)
          else
             size =  0;
          break;
-     default:
-        size = 0;
-       break;
+      default:
+         size = 0;
+      break;
    }
    
    return size;


### PR DESCRIPTION
Seems like Linux's `hexdump` is not available by default on Haiku, and the provided `hd` has a different syntax. I went with `od` which is as far as I know the only 100% Posix solution but the resulting hack is butt-ugly. There's possibly a way to make it prettier (`awk` maybe?) but this one works. Let me know if it's too hackish and I'll try to figure out another way to do this.