### PR TITLE
Reduce input lag by 1 frame (Link Branch)

### DIFF
--- a/libretro/libretro.c
+++ b/libretro/libretro.c
@@ -132,7 +132,6 @@ static void audio_callback(void *gb)
 static void vblank1(GB_gameboy_t *gb)
 {
     vblank1_occurred = true;
-    GB_update_keys_status(gb, 0);
     if (audio_out == GB_1)
         audio_callback(gb);
 }
@@ -140,7 +139,6 @@ static void vblank1(GB_gameboy_t *gb)
 static void vblank2(GB_gameboy_t *gb)
 {
     vblank2_occurred = true;
-    GB_update_keys_status(gb, 1);
     if (audio_out == GB_2)
         audio_callback(gb);
 }
@@ -620,6 +618,10 @@ void retro_run(void)
 
     if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE_UPDATE, &updated) && updated)
         check_variables(emulated_devices == 2 ? true : false);
+
+    GB_update_keys_status(&gameboy[0], 0);
+    if (emulated_devices == 2)
+      GB_update_keys_status(&gameboy[1], 1);
 
     vblank1_occurred = vblank2_occurred = false;
     signed delta = 0;


### PR DESCRIPTION
Now on par with Gambatte in 1 Gameboy mode.

Linked mode has now 1 frame of extra lag instead of 2 vs single GB mode for Player 1.
Player 2 varies between 1 and 2 because of the way the refresh happen at different times (you can see image redraws/cuts quite a lot on P2 screen).