### PR TITLE
Link Cable and Subsystem support

### DIFF
--- a/libretro/jni/Android.mk
+++ b/libretro/jni/Android.mk
@@ -27,13 +27,6 @@ CORE_DIR := ../..
 
 include ../Makefile.common
 
-$(CORE_DIR)/libretro/%_boot.c: $(CORE_DIR)/BootROMs/prebuilt/%_boot.bin
-		echo "/* AUTO-GENERATED */" > $@
-		echo "const unsigned char $(notdir $(@:%.c=%))[] = {" >> $@
-		hexdump -v -e '/1 "0x%02x, "' $< >> $@
-		echo "};" >> $@
-		echo "const unsigned $(notdir $(@:%.c=%))_length = sizeof($(notdir $(@:%.c=%)));" >> $@
-
 LOCAL_SRC_FILES := $(SOURCES_CXX) $(SOURCES_C)
 LOCAL_CFLAGS += -DINLINE=inline -DHAVE_STDINT_H -DHAVE_INTTYPES_H -D__LIBRETRO__ -DNDEBUG -D_USE_MATH_DEFINES  -DGB_INTERNAL -std=c99 -I$(CORE_DIR) -DSAMEBOY_CORE_VERSION=\"$(VERSION)\"
 


### PR DESCRIPTION
fix warning

initial link cable implementation

savefile hack for slot 2, both load from the same SRM file but gb2 doesn't save

fix gameboy synchronization thanks to @LIJI32

hook up savestates for GB#2

reduce code duplication

add layout core option

separate core options for single and linked mode

single mode works

fix changing mode between link enabled and disabled

change viewport size

fix emulated model for slot 2

rename the array so it doesn't conflict with the function signature

add audio output selection

add descriptors to P2

implement left-right screen layout option, add ASAN to Makefile

rebase from master

use set geometry instead

better savestate code

Reduce input lag by 1 frame

subsystem support

set emulated devices automatically

standarize core options

rename core options

readd single game link cable

cut code duplication a bit

make link cable a runtime option

disable this for now

cleanup logs

save ram handling for dual mode

fix savefile names