### PR TITLE
One binary needs compiling on the hostcc regardless of target arch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,8 +19,10 @@ endif
 
 ifeq ($(PLATFORM),Darwin)
 DEFAULT := cocoa
+HOSTCC := cc
 else
 DEFAULT := sdl
+HOSTCC := $(CC)
 endif
 
 default: $(DEFAULT)
@@ -330,7 +332,7 @@ $(OBJ)/BootROMs/SameBoyLogo.rle: $(OBJ)/BootROMs/SameBoyLogo.1bpp build/logo-com
 	./build/logo-compress < $< > $@
 
 build/logo-compress: BootROMs/logo-compress.c
-	$(CC) $< -o $@
+	$(HOSTCC) $< -o $@
 
 $(BIN)/BootROMs/agb_boot.bin: BootROMs/cgb_boot.asm
 $(BIN)/BootROMs/cgb_boot_fast.bin: BootROMs/cgb_boot.asm


### PR DESCRIPTION
This is required for any cross-platform compiling of sameboy due to the fact that ``logo-compress`` needs to be run on the host system during compiling.

In the previous build, it was possible to compile the dylib by running the build command twice - but this would end up with an empty ``SameBoyLogo.rle`` rather than the one intended. It would also fail to build on the first try. This builds correctly without needing to be re-run.