### PR TITLE
Makefile fix to enable build for "unix-armv7-hardfloat-neon"

### DIFF
--- a/libretro/Makefile
+++ b/libretro/Makefile
@@ -80,7 +80,7 @@ else ifeq ($(platform), linux-portable)
    LIBM :=   
 # (armv7 a7, hard point, neon based) ### 
 # NESC, SNESC, C64 mini 
-else ifeq ($(platform), classic_armv7_a7)
+else ifeq ($(platform),$(filter $(platform),classic_armv7_a7 unix-armv7-hardfloat-neon))
 	TARGET := $(TARGET_NAME)_libretro.so
 	fpic := -fPIC
   SHARED := -shared -Wl,--version-script=$(CORE_DIR)/libretro/link.T -Wl,--no-undefined


### PR DESCRIPTION
Compilation was not successful for "unix-armv7-hardfloat-neon" (one of the options in libretro-super build scripts).
Added this platform to "classic_armv7_a7" condition.