### PR TITLE
ci: add Linux aarch64 libretro build

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -26,6 +26,10 @@ include:
   - project: 'libretro-infrastructure/ci-templates'
     file: '/linux-x64.yml'
 
+  # Linux ARM 64-bit
+  - project: 'libretro-infrastructure/ci-templates'
+    file: '/linux-aarch64.yml'
+
   # Linux 32-bit
   - project: 'libretro-infrastructure/ci-templates'
     file: '/linux-i686.yml'
@@ -100,6 +104,12 @@ libretro-build-windows-i686:
 libretro-build-linux-x64:
   extends:
     - .libretro-linux-x64-make-default
+    - .core-defs
+
+# Linux ARM 64-bit
+libretro-build-linux-aarch64:
+  extends:
+    - .libretro-linux-aarch64-make-default
     - .core-defs
 
 # Linux 32-bit


### PR DESCRIPTION
The buildbot publishes `sameboy_libretro.so` for linux/x86_64 and linux/x86, but there is no desktop Linux ARM64 build — `.gitlab-ci.yml` has no aarch64 job, so nothing is produced for that platform.

This adds the `/linux-aarch64.yml` template include and a `libretro-build-linux-aarch64` job, mirroring the existing x64 one. It is the same shape dozens of cores already use, and needs no image or compiler override: the `libretro-build-aarch64-ubuntu` image installs gcc-12/g++-12 and points `gcc`/`g++` at them through `update-alternatives`.

**Verified on real aarch64 hardware:**

- Builds clean from this branch: `make -C libretro platform=unix` produces `sameboy_libretro.so`.
- The core runs. Driven through a minimal libretro front end it initialises as model `dmg`, negotiates XRGB8888, loads content, renders 400 frames at 160x144, then unloads and deinitialises cleanly.
- Rendering is correct, not merely non-empty: running **dmg-acid2** (Matt Currie's PPU accuracy test) produces its reference image — the "HELLO WORLD!" banner, the face with both eyes, nose and mouth, and the caption. A broken PPU path in the ARM64 build would show up as visibly mangled output, since that is exactly what the ROM is designed to detect.

Only the Linux ARM64 job is added; nothing else changes, and the file's CRLF line endings are preserved.